### PR TITLE
Add `heading` option to match custom headings

### DIFF
--- a/fixtures/match-heading/expected.md
+++ b/fixtures/match-heading/expected.md
@@ -1,0 +1,8 @@
+# Example
+
+## Mitwirkende
+
+| Name      | Website                 |
+| --------- | ----------------------- |
+| **Sara**  | <https://example.com#1> |
+| **Alice** | <https://example.com#2> |

--- a/fixtures/match-heading/index.md
+++ b/fixtures/match-heading/index.md
@@ -1,0 +1,3 @@
+# Example
+
+## Mitwirkende

--- a/fixtures/match-heading/package.json
+++ b/fixtures/match-heading/package.json
@@ -1,0 +1,6 @@
+{
+  "contributors": [
+    "Sara (https://example.com#1)",
+    "Alice (https://example.com#2)"
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -16,17 +16,7 @@ function contributors(options) {
   var align = settings.align || null
   var defaultContributors = settings.contributors
   var formatters = createFormatters(settings.formatters)
-  var contributorsHeadingRegexp = 'contributors'
-
-  if (settings.heading) {
-    contributorsHeadingRegexp = settings.heading
-    if (typeof settings.heading === 'string') {
-      contributorsHeadingRegexp = new RegExp(
-        '^(' + settings.heading + ')$',
-        'i'
-      )
-    }
-  }
+  var contributorsHeading = settings.heading || 'contributors'
 
   return transform
 
@@ -99,7 +89,7 @@ function contributors(options) {
       var table = createTable(contributors, formatters, align)
       var headingFound = false
 
-      heading(tree, contributorsHeadingRegexp, onheading)
+      heading(tree, contributorsHeading, onheading)
 
       // Add the section if not found but with `appendIfMissing`.
       if (!headingFound && settings.appendIfMissing) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function contributors(options) {
   var align = settings.align || null
   var defaultContributors = settings.contributors
   var formatters = createFormatters(settings.formatters)
-  var contributorsHeadingRegexp = settings.match || /^contributors$/i
+  var contributorsHeadingRegexp = settings.heading || /^contributors$/i
 
   return transform
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,18 @@ function contributors(options) {
   var align = settings.align || null
   var defaultContributors = settings.contributors
   var formatters = createFormatters(settings.formatters)
-  var contributorsHeadingRegexp = settings.heading || /^contributors$/i
+  var contributorsHeadingRegexp = /^contributors$/i
+
+  if (settings.heading) {
+    if (typeof settings.heading === 'string') {
+      contributorsHeadingRegexp = new RegExp(
+        '^(' + settings.heading + ')$',
+        'i'
+      )
+    } else {
+      contributorsHeadingRegexp = settings.heading
+    }
+  }
 
   return transform
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function contributors(options) {
   var align = settings.align || null
   var defaultContributors = settings.contributors
   var formatters = createFormatters(settings.formatters)
+  var contributorsHeadingRegexp = settings.match || /^contributors$/i
 
   return transform
 
@@ -88,7 +89,7 @@ function contributors(options) {
       var table = createTable(contributors, formatters, align)
       var headingFound = false
 
-      heading(tree, 'contributors', onheading)
+      heading(tree, contributorsHeadingRegexp, onheading)
 
       // Add the section if not found but with `appendIfMissing`.
       if (!headingFound && settings.appendIfMissing) {

--- a/index.js
+++ b/index.js
@@ -16,16 +16,15 @@ function contributors(options) {
   var align = settings.align || null
   var defaultContributors = settings.contributors
   var formatters = createFormatters(settings.formatters)
-  var contributorsHeadingRegexp = /^contributors$/i
+  var contributorsHeadingRegexp = 'contributors'
 
   if (settings.heading) {
+    contributorsHeadingRegexp = settings.heading
     if (typeof settings.heading === 'string') {
       contributorsHeadingRegexp = new RegExp(
         '^(' + settings.heading + ')$',
         'i'
       )
-    } else {
-      contributorsHeadingRegexp = settings.heading
     }
   }
 

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ MIT
 
 Inject a given list of contributors.
 
-*   Looks for the first heading containing `'Contributors'` (case insensitive)
+*   Looks for the first heading matching `/^contributors$/i` or `options.match`
 *   If no heading is found and `appendIfMissing` is set, inject such a heading
 *   Replaces the table in that section if there is one, or injects it otherwise
 
@@ -106,6 +106,10 @@ default: `null`).
 ###### `options.appendIfMissing`
 
 Inject the section if there is none (`boolean`, default: `false`).
+
+###### `options.match`
+
+Regular expression to match contributors heading (`regexp`, default: `/^contributors$/i`).
 
 ###### `options.formatters`
 

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ Inject the section if there is none (`boolean`, default: `false`).
 
 ###### `options.heading`
 
-Heading to look for (`regexp`, default: `/^contributors$/i`).
+Heading to look for (`string` (case-insensitive) or `regexp`, default: `'contributors'`).
 
 ###### `options.formatters`
 

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ MIT
 
 Inject a given list of contributors.
 
-*   Looks for the first heading matching `/^contributors$/i` or `options.match`
+*   Looks for the first heading matching `/^contributors$/i` or `options.heading`
 *   If no heading is found and `appendIfMissing` is set, inject such a heading
 *   Replaces the table in that section if there is one, or injects it otherwise
 
@@ -107,9 +107,9 @@ default: `null`).
 
 Inject the section if there is none (`boolean`, default: `false`).
 
-###### `options.match`
+###### `options.heading`
 
-Regular expression to match contributors heading (`regexp`, default: `/^contributors$/i`).
+Heading to look for (`regexp`, default: `/^contributors$/i`).
 
 ###### `options.formatters`
 

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ Inject the section if there is none (`boolean`, default: `false`).
 
 ###### `options.heading`
 
-Heading to look for (`string` (case-insensitive) or `regexp`, default: `'contributors'`).
+Heading to look for (`string` (case-insensitive) or `RegExp`, default: `'contributors'`).
 
 ###### `options.formatters`
 

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ try {
 test.onFinish(ondone)
 
 test('remark-contributors', function (t) {
-  t.plan(16)
+  t.plan(17)
 
   remark()
     .use(gfm)
@@ -408,7 +408,26 @@ test('remark-contributors', function (t) {
             null,
             String(read(path.join('fixtures', 'match-heading', 'expected.md')))
           ],
-          'should match custom heading if `heading` option is passed'
+          'should match custom heading if `heading` option is passed a regex'
+        )
+      }
+    )
+
+  remark()
+    .use(gfm)
+    .use(contributors, {
+      heading: 'mitwirkende'
+    })
+    .process(
+      read(path.join('fixtures', 'match-heading', 'index.md')),
+      function (err, file) {
+        t.deepEqual(
+          [err, String(file)],
+          [
+            null,
+            String(read(path.join('fixtures', 'match-heading', 'expected.md')))
+          ],
+          'should match custom heading if `heading` option is passed a string'
         )
       }
     )

--- a/test.js
+++ b/test.js
@@ -397,7 +397,7 @@ test('remark-contributors', function (t) {
   remark()
     .use(gfm)
     .use(contributors, {
-      match: /^mitwirkende$/i
+      heading: /^mitwirkende$/i
     })
     .process(
       read(path.join('fixtures', 'match-heading', 'index.md')),
@@ -408,7 +408,7 @@ test('remark-contributors', function (t) {
             null,
             String(read(path.join('fixtures', 'match-heading', 'expected.md')))
           ],
-          'should match custom heading if `match` option is passed'
+          'should match custom heading if `heading` option is passed'
         )
       }
     )

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ try {
 test.onFinish(ondone)
 
 test('remark-contributors', function (t) {
-  t.plan(15)
+  t.plan(16)
 
   remark()
     .use(gfm)
@@ -390,6 +390,25 @@ test('remark-contributors', function (t) {
         t.ok(
           /Missing required `contributors` in settings/.test(err),
           'should throw if no contributors are given or found'
+        )
+      }
+    )
+
+  remark()
+    .use(gfm)
+    .use(contributors, {
+      match: /^mitwirkende$/i
+    })
+    .process(
+      read(path.join('fixtures', 'match-heading', 'index.md')),
+      function (err, file) {
+        t.deepEqual(
+          [err, String(file)],
+          [
+            null,
+            String(read(path.join('fixtures', 'match-heading', 'expected.md')))
+          ],
+          'should match custom heading if `match` option is passed'
         )
       }
     )


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

Closes #16.

Most of this is described in the respective issue. Motivation behind this was that I basically have a multilingual readme setup but `remark-contributors` only works on english readmes. I'm not sure the name of the option is perfect. I'm fine with `match`, `regexp` and `matchHeading`, currently this pull request uses `match`.

Inspired by https://github.com/remarkjs/remark-license/pull/13.